### PR TITLE
Add core game singleton and scene loader utility

### DIFF
--- a/Idle Skiller/Assets/Utilities.meta
+++ b/Idle Skiller/Assets/Utilities.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 80dd7c3227f645e09a76a38af903b076
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Idle Skiller/Assets/Utilities/SceneLoader.cs
+++ b/Idle Skiller/Assets/Utilities/SceneLoader.cs
@@ -1,0 +1,22 @@
+using System.Collections;
+using UnityEngine.SceneManagement;
+
+namespace IdleSkiller.Utilities
+{
+    public static class SceneLoader
+    {
+        public static void Load(string sceneName)
+        {
+            SceneManager.LoadScene(sceneName);
+        }
+
+        public static IEnumerator LoadAsync(string sceneName)
+        {
+            var operation = SceneManager.LoadSceneAsync(sceneName);
+            while (!operation.isDone)
+            {
+                yield return null;
+            }
+        }
+    }
+}

--- a/Idle Skiller/Assets/Utilities/SceneLoader.cs.meta
+++ b/Idle Skiller/Assets/Utilities/SceneLoader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d352357bbc9b48e9ba001443e2713fea
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Idle Skiller/Assets/_Project.meta
+++ b/Idle Skiller/Assets/_Project.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 09299520d23847ce845f93981a31acfc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Idle Skiller/Assets/_Project/Scripts.meta
+++ b/Idle Skiller/Assets/_Project/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d74e3b66e6c74b3a955da380ef0ca694
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Idle Skiller/Assets/_Project/Scripts/Core.meta
+++ b/Idle Skiller/Assets/_Project/Scripts/Core.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b44f9a4f566a4744a249105e49c5b341
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Idle Skiller/Assets/_Project/Scripts/Core/Game.cs
+++ b/Idle Skiller/Assets/_Project/Scripts/Core/Game.cs
@@ -1,0 +1,28 @@
+using UnityEngine;
+
+namespace IdleSkiller.Core
+{
+    public class Game : MonoBehaviour
+    {
+        public static Game Instance { get; private set; }
+
+        public GameState State { get; private set; }
+
+        private void Awake()
+        {
+            if (Instance != null && Instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            Instance = this;
+            DontDestroyOnLoad(gameObject);
+        }
+
+        public void SetState(GameState newState)
+        {
+            State = newState;
+        }
+    }
+}

--- a/Idle Skiller/Assets/_Project/Scripts/Core/Game.cs.meta
+++ b/Idle Skiller/Assets/_Project/Scripts/Core/Game.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4742fe9f936848d3ae08a4ac26ba4cb2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Idle Skiller/Assets/_Project/Scripts/Core/GameState.cs
+++ b/Idle Skiller/Assets/_Project/Scripts/Core/GameState.cs
@@ -1,0 +1,10 @@
+namespace IdleSkiller.Core
+{
+    public enum GameState
+    {
+        Boot,
+        MainMenu,
+        Gameplay,
+        Paused
+    }
+}

--- a/Idle Skiller/Assets/_Project/Scripts/Core/GameState.cs.meta
+++ b/Idle Skiller/Assets/_Project/Scripts/Core/GameState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bbde338e2ec9424ca5d4d5b18c4426ed
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- Add persistent `Game` singleton with simple state management
- Introduce `GameState` enum for boot, menu, gameplay, and paused states
- Add `SceneLoader` helper for synchronous and asynchronous scene loading

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2ba47528832687843299b90757e5