### PR TITLE
Add time service and offline grant calculations

### DIFF
--- a/Idle Skiller/Assets/_Project/Scripts/Core/Time/ITimeService.cs
+++ b/Idle Skiller/Assets/_Project/Scripts/Core/Time/ITimeService.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace IdleSkiller.Core.Time
+{
+    /// <summary>
+    /// Abstraction over time retrieval to allow deterministic testing.
+    /// </summary>
+    public interface ITimeService
+    {
+        /// <summary>
+        /// Gets the current UTC time.
+        /// </summary>
+        DateTime UtcNow { get; }
+    }
+}

--- a/Idle Skiller/Assets/_Project/Scripts/Core/Time/OfflineGrant.cs
+++ b/Idle Skiller/Assets/_Project/Scripts/Core/Time/OfflineGrant.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace IdleSkiller.Core.Time
+{
+    /// <summary>
+    /// Provides helper methods for calculating offline progress.
+    /// </summary>
+    public static class OfflineGrant
+    {
+        /// <summary>
+        /// Calculates the number of completed cycles that would have occurred
+        /// during an offline period.
+        /// </summary>
+        /// <param name="elapsed">The elapsed offline time in seconds.</param>
+        /// <param name="duration">The duration of a single cycle in seconds.</param>
+        /// <param name="speedMultiplier">Speed multiplier applied to the process.</param>
+        /// <returns>The number of fully completed cycles.</returns>
+        public static int CompletedCycles(double elapsed, double duration, double speedMultiplier)
+        {
+            if (elapsed <= 0 || duration <= 0 || speedMultiplier <= 0)
+            {
+                return 0;
+            }
+
+            var cycles = elapsed * speedMultiplier / duration;
+            return (int)Math.Floor(cycles);
+        }
+    }
+}

--- a/Idle Skiller/Assets/_Project/Scripts/Core/Time/TimeService.cs
+++ b/Idle Skiller/Assets/_Project/Scripts/Core/Time/TimeService.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace IdleSkiller.Core.Time
+{
+    /// <summary>
+    /// Default implementation of <see cref="ITimeService"/> using <see cref="DateTime.UtcNow"/>.
+    /// </summary>
+    public class TimeService : ITimeService
+    {
+        /// <inheritdoc />
+        public DateTime UtcNow => DateTime.UtcNow;
+    }
+}

--- a/Idle Skiller/Assets/_Project/Tests/Tests.csproj
+++ b/Idle Skiller/Assets/_Project/Tests/Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="../Scripts/Core/Time/*.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="4.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+  </ItemGroup>
+</Project>

--- a/Idle Skiller/Assets/_Project/Tests/TimeServiceTests.cs
+++ b/Idle Skiller/Assets/_Project/Tests/TimeServiceTests.cs
@@ -1,0 +1,34 @@
+using System;
+using IdleSkiller.Core.Time;
+using NUnit.Framework;
+
+namespace IdleSkiller.Tests
+{
+    public class TimeServiceTests
+    {
+        [Test]
+        public void UtcNow_ReturnsCurrentTime()
+        {
+            var service = new TimeService();
+            var before = DateTime.UtcNow;
+
+            var serviceNow = service.UtcNow;
+
+            var after = DateTime.UtcNow;
+            Assert.That(serviceNow, Is.GreaterThanOrEqualTo(before).And.LessThanOrEqualTo(after));
+        }
+
+        [Test]
+        [TestCase(10, 2, 1, 5)]
+        [TestCase(10, 3, 1, 3)]
+        [TestCase(10, 2, 2, 10)]
+        [TestCase(0, 5, 1, 0)]
+        [TestCase(10, 0, 1, 0)]
+        [TestCase(10, 5, 0, 0)]
+        public void CompletedCycles_ComputesExpected(double elapsed, double duration, double speedMultiplier, int expected)
+        {
+            var result = OfflineGrant.CompletedCycles(elapsed, duration, speedMultiplier);
+            Assert.That(result, Is.EqualTo(expected));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Implement time abstraction via ITimeService and TimeService
- Introduce OfflineGrant utility for offline cycle calculations
- Add unit tests for time service and offline grant

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2f53cb50832688ef2ff271c5ff24