### PR TITLE
feat: add basic save system

### DIFF
--- a/Idle Skiller/Assets/_Project/Scripts/Core/Save.meta
+++ b/Idle Skiller/Assets/_Project/Scripts/Core/Save.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7f05141198744d66be659b8af2267220
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Idle Skiller/Assets/_Project/Scripts/Core/Save/Editor.meta
+++ b/Idle Skiller/Assets/_Project/Scripts/Core/Save/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a8aca05b9cc844a0a9663d045d4c2de4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Idle Skiller/Assets/_Project/Scripts/Core/Save/Editor/SaveSystemEditorWindow.cs
+++ b/Idle Skiller/Assets/_Project/Scripts/Core/Save/Editor/SaveSystemEditorWindow.cs
@@ -1,0 +1,50 @@
+#if UNITY_EDITOR
+using System;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+
+namespace IdleSkiller.Core.Save
+{
+    public class SaveSystemEditorWindow : EditorWindow
+    {
+        private ISaveSystem saveSystem;
+        private SaveData data;
+
+        [MenuItem("IdleSkiller/Save System Debug")]
+        public static void ShowWindow()
+        {
+            GetWindow<SaveSystemEditorWindow>("Save Debug");
+        }
+
+        private void OnEnable()
+        {
+            saveSystem = new SaveSystem();
+            data = saveSystem.Load();
+        }
+
+        private void OnGUI()
+        {
+            data.Gold = EditorGUILayout.IntField("Gold", data.Gold);
+            data.Gems = EditorGUILayout.IntField("Gems", data.Gems);
+            data.Fame = EditorGUILayout.IntField("Fame", data.Fame);
+            data.Workers = EditorGUILayout.IntField("Workers", data.Workers);
+            data.Guild = EditorGUILayout.TextField("Guild", data.Guild);
+
+            var inventoryString = string.Join(",", data.Inventory);
+            inventoryString = EditorGUILayout.TextField("Inventory", inventoryString);
+            data.Inventory = new List<string>(inventoryString.Split(new[] {','}, StringSplitOptions.RemoveEmptyEntries));
+
+            if (GUILayout.Button("Save"))
+            {
+                saveSystem.Save(data);
+            }
+
+            if (GUILayout.Button("Load"))
+            {
+                data = saveSystem.Load();
+            }
+        }
+    }
+}
+#endif

--- a/Idle Skiller/Assets/_Project/Scripts/Core/Save/Editor/SaveSystemEditorWindow.cs.meta
+++ b/Idle Skiller/Assets/_Project/Scripts/Core/Save/Editor/SaveSystemEditorWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4118e1197f7e4c43a50b0953fe4c3f73
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Idle Skiller/Assets/_Project/Scripts/Core/Save/ISaveSystem.cs
+++ b/Idle Skiller/Assets/_Project/Scripts/Core/Save/ISaveSystem.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace IdleSkiller.Core.Save
+{
+    public interface ISaveSystem
+    {
+        SaveData Load();
+        void Save(SaveData data);
+        bool HasSave();
+    }
+}

--- a/Idle Skiller/Assets/_Project/Scripts/Core/Save/ISaveSystem.cs.meta
+++ b/Idle Skiller/Assets/_Project/Scripts/Core/Save/ISaveSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 97b0cc53217e448281ccc7c41691ec24
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Idle Skiller/Assets/_Project/Scripts/Core/Save/SaveData.cs
+++ b/Idle Skiller/Assets/_Project/Scripts/Core/Save/SaveData.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+
+namespace IdleSkiller.Core.Save
+{
+    [Serializable]
+    public class SaveData
+    {
+        public const int CURRENT_VERSION = 1;
+
+        public int Version = CURRENT_VERSION;
+        public int Gold;
+        public int Gems;
+        public int Fame;
+        public List<string> Inventory = new List<string>();
+        public int Workers;
+        public string Guild;
+    }
+}

--- a/Idle Skiller/Assets/_Project/Scripts/Core/Save/SaveData.cs.meta
+++ b/Idle Skiller/Assets/_Project/Scripts/Core/Save/SaveData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8717df80d7af44f3b48263ba2be180f5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Idle Skiller/Assets/_Project/Scripts/Core/Save/SaveSystem.cs
+++ b/Idle Skiller/Assets/_Project/Scripts/Core/Save/SaveSystem.cs
@@ -1,0 +1,48 @@
+using UnityEngine;
+
+namespace IdleSkiller.Core.Save
+{
+    public class SaveSystem : ISaveSystem
+    {
+        private const string PlayerPrefsKey = "save";
+
+        public SaveData Load()
+        {
+            if (!PlayerPrefs.HasKey(PlayerPrefsKey))
+            {
+                return new SaveData();
+            }
+
+            var json = PlayerPrefs.GetString(PlayerPrefsKey);
+            var data = new SaveData();
+            JsonUtility.FromJsonOverwrite(json, data);
+
+            if (data.Version != SaveData.CURRENT_VERSION)
+            {
+                data = Migrate(data);
+            }
+
+            return data;
+        }
+
+        public void Save(SaveData data)
+        {
+            data.Version = SaveData.CURRENT_VERSION;
+            var json = JsonUtility.ToJson(data);
+            PlayerPrefs.SetString(PlayerPrefsKey, json);
+            PlayerPrefs.Save();
+        }
+
+        public bool HasSave()
+        {
+            return PlayerPrefs.HasKey(PlayerPrefsKey);
+        }
+
+        private SaveData Migrate(SaveData data)
+        {
+            // Placeholder for future data migrations
+            data.Version = SaveData.CURRENT_VERSION;
+            return data;
+        }
+    }
+}

--- a/Idle Skiller/Assets/_Project/Scripts/Core/Save/SaveSystem.cs.meta
+++ b/Idle Skiller/Assets/_Project/Scripts/Core/Save/SaveSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 461c51686d67423fa0f4de8c5111c2c7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- add SaveData model and SaveSystem for PlayerPrefs JSON persistence
- include version field and migration stub
- add editor window for manual save/load debugging

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae30d0eeb8832683757d1757b2575e