### PR TITLE
Add ScriptableObject data definitions and samples

### DIFF
--- a/Idle Skiller/Assets/_Project/Data.meta
+++ b/Idle Skiller/Assets/_Project/Data.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 25d767169230ab85a6567820870a9cba
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Idle Skiller/Assets/_Project/Data/SampleEnemy.asset
+++ b/Idle Skiller/Assets/_Project/Data/SampleEnemy.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ede9f0b8e2a2e7d5f315cc0f07c8e9a4, type: 3}
+  m_Name: SampleEnemy
+  m_EditorClassIdentifier: 
+  Id: sample_enemy
+  DisplayName: Sample Enemy
+  MaxHealth: 10
+  Loot: {fileID: 11400000, guid: 4aa7ed72ef3870b53cfe77cd50e14a60, type: 2}

--- a/Idle Skiller/Assets/_Project/Data/SampleEnemy.asset.meta
+++ b/Idle Skiller/Assets/_Project/Data/SampleEnemy.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8a71a5eac6f3f1dba4fd1c7a4d6b0453
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Idle Skiller/Assets/_Project/Data/SampleItem.asset
+++ b/Idle Skiller/Assets/_Project/Data/SampleItem.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86f439d528e5ce64e7fb6885cdcbdc2d, type: 3}
+  m_Name: SampleItem
+  m_EditorClassIdentifier: 
+  Id: sample_item
+  DisplayName: Sample Item
+  Description: Example item
+  Icon: {fileID: 0}
+  MaxStack: 10

--- a/Idle Skiller/Assets/_Project/Data/SampleItem.asset.meta
+++ b/Idle Skiller/Assets/_Project/Data/SampleItem.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fab5f25d870d681ddff1c294a79fe3a6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Idle Skiller/Assets/_Project/Data/SampleLootTable.asset
+++ b/Idle Skiller/Assets/_Project/Data/SampleLootTable.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f68ccac63f6c76c02b036b82945fc19e, type: 3}
+  m_Name: SampleLootTable
+  m_EditorClassIdentifier: 
+  Entries:
+  - Item: {fileID: 11400000, guid: fab5f25d870d681ddff1c294a79fe3a6, type: 2}
+    Weight: 1

--- a/Idle Skiller/Assets/_Project/Data/SampleLootTable.asset.meta
+++ b/Idle Skiller/Assets/_Project/Data/SampleLootTable.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4aa7ed72ef3870b53cfe77cd50e14a60
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Idle Skiller/Assets/_Project/Data/SampleQuest.asset
+++ b/Idle Skiller/Assets/_Project/Data/SampleQuest.asset
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c3c8225d76799eb99860ea80ef0a4643, type: 3}
+  m_Name: SampleQuest
+  m_EditorClassIdentifier: 
+  Id: sample_quest
+  DisplayName: Sample Quest
+  Description: Example quest
+  Rewards:
+  - Item: {fileID: 11400000, guid: fab5f25d870d681ddff1c294a79fe3a6, type: 2}
+    Amount: 5

--- a/Idle Skiller/Assets/_Project/Data/SampleQuest.asset.meta
+++ b/Idle Skiller/Assets/_Project/Data/SampleQuest.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 60b3ffd073eb3d557d0bb367d41e5591
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Idle Skiller/Assets/_Project/Data/SampleRecipe.asset
+++ b/Idle Skiller/Assets/_Project/Data/SampleRecipe.asset
@@ -1,0 +1,21 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ccb3d309769d31cba26f6081a0af9c4a, type: 3}
+  m_Name: SampleRecipe
+  m_EditorClassIdentifier: 
+  Id: sample_recipe
+  Ingredients:
+  - Item: {fileID: 11400000, guid: fab5f25d870d681ddff1c294a79fe3a6, type: 2}
+    Amount: 2
+  Result:
+    Item: {fileID: 11400000, guid: fab5f25d870d681ddff1c294a79fe3a6, type: 2}
+    Amount: 1

--- a/Idle Skiller/Assets/_Project/Data/SampleRecipe.asset.meta
+++ b/Idle Skiller/Assets/_Project/Data/SampleRecipe.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 82df771d324ad14e146db5eba16cbc6a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Idle Skiller/Assets/_Project/Data/SampleSkill.asset
+++ b/Idle Skiller/Assets/_Project/Data/SampleSkill.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bc28474ce22edfa53f340e59859e0ad1, type: 3}
+  m_Name: SampleSkill
+  m_EditorClassIdentifier: 
+  Id: sample_skill
+  DisplayName: Sample Skill
+  Description: Example skill
+  Icon: {fileID: 0}

--- a/Idle Skiller/Assets/_Project/Data/SampleSkill.asset.meta
+++ b/Idle Skiller/Assets/_Project/Data/SampleSkill.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 010c8a38c8ee6df46fc16df6dd367560
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Idle Skiller/Assets/_Project/Scripts/Data.meta
+++ b/Idle Skiller/Assets/_Project/Scripts/Data.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 05a86cc8cb403330a00dcf02b5afba37
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Idle Skiller/Assets/_Project/Scripts/Data/EnemyDef.cs
+++ b/Idle Skiller/Assets/_Project/Scripts/Data/EnemyDef.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+namespace IdleSkiller.Data
+{
+    [CreateAssetMenu(menuName = "IdleSkiller/Enemy")]
+    public class EnemyDef : ScriptableObject
+    {
+        public string Id;
+        public string DisplayName;
+        public int MaxHealth;
+        public LootTable Loot;
+    }
+}

--- a/Idle Skiller/Assets/_Project/Scripts/Data/EnemyDef.cs.meta
+++ b/Idle Skiller/Assets/_Project/Scripts/Data/EnemyDef.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ede9f0b8e2a2e7d5f315cc0f07c8e9a4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Idle Skiller/Assets/_Project/Scripts/Data/ItemDef.cs
+++ b/Idle Skiller/Assets/_Project/Scripts/Data/ItemDef.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+
+namespace IdleSkiller.Data
+{
+    [CreateAssetMenu(menuName = "IdleSkiller/Item")]
+    public class ItemDef : ScriptableObject
+    {
+        public string Id;
+        public string DisplayName;
+        [TextArea] public string Description;
+        public Sprite Icon;
+        public int MaxStack = 1;
+    }
+}

--- a/Idle Skiller/Assets/_Project/Scripts/Data/ItemDef.cs.meta
+++ b/Idle Skiller/Assets/_Project/Scripts/Data/ItemDef.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 86f439d528e5ce64e7fb6885cdcbdc2d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Idle Skiller/Assets/_Project/Scripts/Data/LootTable.cs
+++ b/Idle Skiller/Assets/_Project/Scripts/Data/LootTable.cs
@@ -1,0 +1,17 @@
+using UnityEngine;
+
+namespace IdleSkiller.Data
+{
+    [CreateAssetMenu(menuName = "IdleSkiller/LootTable")]
+    public class LootTable : ScriptableObject
+    {
+        [System.Serializable]
+        public struct Entry
+        {
+            public ItemDef Item;
+            public float Weight;
+        }
+
+        public Entry[] Entries;
+    }
+}

--- a/Idle Skiller/Assets/_Project/Scripts/Data/LootTable.cs.meta
+++ b/Idle Skiller/Assets/_Project/Scripts/Data/LootTable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f68ccac63f6c76c02b036b82945fc19e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Idle Skiller/Assets/_Project/Scripts/Data/QuestDef.cs
+++ b/Idle Skiller/Assets/_Project/Scripts/Data/QuestDef.cs
@@ -1,0 +1,20 @@
+using UnityEngine;
+
+namespace IdleSkiller.Data
+{
+    [CreateAssetMenu(menuName = "IdleSkiller/Quest")]
+    public class QuestDef : ScriptableObject
+    {
+        [System.Serializable]
+        public struct ItemStack
+        {
+            public ItemDef Item;
+            public int Amount;
+        }
+
+        public string Id;
+        public string DisplayName;
+        [TextArea] public string Description;
+        public ItemStack[] Rewards;
+    }
+}

--- a/Idle Skiller/Assets/_Project/Scripts/Data/QuestDef.cs.meta
+++ b/Idle Skiller/Assets/_Project/Scripts/Data/QuestDef.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c3c8225d76799eb99860ea80ef0a4643
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Idle Skiller/Assets/_Project/Scripts/Data/README.md
+++ b/Idle Skiller/Assets/_Project/Scripts/Data/README.md
@@ -1,0 +1,36 @@
+# Data Definitions
+
+This folder contains ScriptableObject types used to configure game content. Designers can create new assets in `/Assets/_Project/Data` without code changes.
+
+## SkillDef
+* `Id` - unique identifier
+* `DisplayName` - human readable name
+* `Description` - text description
+* `Icon` - sprite shown in UI
+
+## ItemDef
+* `Id` - unique identifier
+* `DisplayName` - human readable name
+* `Description` - text description
+* `Icon` - sprite shown in UI
+* `MaxStack` - maximum stack size
+
+## RecipeDef
+* `Id` - unique identifier
+* `Ingredients` - list of input item stacks
+* `Result` - output item stack
+
+## QuestDef
+* `Id` - unique identifier
+* `DisplayName` - human readable name
+* `Description` - text description
+* `Rewards` - item stacks granted on completion
+
+## EnemyDef
+* `Id` - unique identifier
+* `DisplayName` - human readable name
+* `MaxHealth` - hit points
+* `Loot` - loot table used on defeat
+
+## LootTable
+* `Entries` - weighted items that can drop

--- a/Idle Skiller/Assets/_Project/Scripts/Data/README.md.meta
+++ b/Idle Skiller/Assets/_Project/Scripts/Data/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 49218c61d971fef546dbee5a91192e20
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Idle Skiller/Assets/_Project/Scripts/Data/RecipeDef.cs
+++ b/Idle Skiller/Assets/_Project/Scripts/Data/RecipeDef.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+
+namespace IdleSkiller.Data
+{
+    [CreateAssetMenu(menuName = "IdleSkiller/Recipe")]
+    public class RecipeDef : ScriptableObject
+    {
+        [System.Serializable]
+        public struct ItemStack
+        {
+            public ItemDef Item;
+            public int Amount;
+        }
+
+        public string Id;
+        public ItemStack[] Ingredients;
+        public ItemStack Result;
+    }
+}

--- a/Idle Skiller/Assets/_Project/Scripts/Data/RecipeDef.cs.meta
+++ b/Idle Skiller/Assets/_Project/Scripts/Data/RecipeDef.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ccb3d309769d31cba26f6081a0af9c4a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Idle Skiller/Assets/_Project/Scripts/Data/SkillDef.cs
+++ b/Idle Skiller/Assets/_Project/Scripts/Data/SkillDef.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+namespace IdleSkiller.Data
+{
+    [CreateAssetMenu(menuName = "IdleSkiller/Skill")]
+    public class SkillDef : ScriptableObject
+    {
+        public string Id;
+        public string DisplayName;
+        [TextArea] public string Description;
+        public Sprite Icon;
+    }
+}

--- a/Idle Skiller/Assets/_Project/Scripts/Data/SkillDef.cs.meta
+++ b/Idle Skiller/Assets/_Project/Scripts/Data/SkillDef.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bc28474ce22edfa53f340e59859e0ad1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add Skill, Item, Recipe, Quest, Enemy and LootTable ScriptableObjects
- sample data assets for designers under Assets/_Project/Data
- document fields for all definitions

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 errors when accessing repositories)*

------
https://chatgpt.com/codex/tasks/task_e_68ae30e0b4b8832685ea7a1fdba98e9d