### PR TITLE
Add lightweight event bus infrastructure

### DIFF
--- a/Idle Skiller/Assets/_Project/Scripts/Core/Events/CurrencyChanged.cs
+++ b/Idle Skiller/Assets/_Project/Scripts/Core/Events/CurrencyChanged.cs
@@ -1,0 +1,16 @@
+namespace IdleSkiller.Core.Events
+{
+    public readonly struct CurrencyChanged
+    {
+        public readonly int Gold;
+        public readonly int Gems;
+        public readonly int Fame;
+
+        public CurrencyChanged(int gold, int gems, int fame)
+        {
+            Gold = gold;
+            Gems = gems;
+            Fame = fame;
+        }
+    }
+}

--- a/Idle Skiller/Assets/_Project/Scripts/Core/Events/EventBus.cs
+++ b/Idle Skiller/Assets/_Project/Scripts/Core/Events/EventBus.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+
+namespace IdleSkiller.Core.Events
+{
+    public class EventBus : IEventBus
+    {
+        private class EventStream<T> where T : struct
+        {
+            private readonly List<Action<T>> _handlers = new();
+            private Action<T>[] _invokeList = Array.Empty<Action<T>>();
+            private bool _dirty = true;
+
+            public void Subscribe(Action<T> handler)
+            {
+                _handlers.Add(handler);
+                _dirty = true;
+            }
+
+            public void Unsubscribe(Action<T> handler)
+            {
+                if (_handlers.Remove(handler))
+                {
+                    _dirty = true;
+                }
+            }
+
+            public void Publish(in T eventData)
+            {
+                if (_dirty)
+                {
+                    _invokeList = _handlers.ToArray();
+                    _dirty = false;
+                }
+
+                for (int i = 0; i < _invokeList.Length; i++)
+                {
+                    _invokeList[i]?.Invoke(eventData);
+                }
+            }
+        }
+
+        private readonly Dictionary<Type, object> _streams = new();
+
+        private EventStream<T> GetStream<T>() where T : struct
+        {
+            var type = typeof(T);
+            if (!_streams.TryGetValue(type, out var stream))
+            {
+                stream = new EventStream<T>();
+                _streams[type] = stream;
+            }
+
+            return (EventStream<T>)stream;
+        }
+
+        public void Subscribe<T>(Action<T> handler) where T : struct => GetStream<T>().Subscribe(handler);
+
+        public void Unsubscribe<T>(Action<T> handler) where T : struct => GetStream<T>().Unsubscribe(handler);
+
+        public void Publish<T>(in T eventData) where T : struct => GetStream<T>().Publish(eventData);
+    }
+}

--- a/Idle Skiller/Assets/_Project/Scripts/Core/Events/IEventBus.cs
+++ b/Idle Skiller/Assets/_Project/Scripts/Core/Events/IEventBus.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace IdleSkiller.Core.Events
+{
+    public interface IEventBus
+    {
+        void Subscribe<T>(Action<T> handler) where T : struct;
+        void Unsubscribe<T>(Action<T> handler) where T : struct;
+        void Publish<T>(in T eventData) where T : struct;
+    }
+}

--- a/Idle Skiller/Assets/_Project/Scripts/Core/Events/JobCompleted.cs
+++ b/Idle Skiller/Assets/_Project/Scripts/Core/Events/JobCompleted.cs
@@ -1,0 +1,12 @@
+namespace IdleSkiller.Core.Events
+{
+    public readonly struct JobCompleted
+    {
+        public readonly string JobId;
+
+        public JobCompleted(string jobId)
+        {
+            JobId = jobId;
+        }
+    }
+}

--- a/Idle Skiller/Assets/_Project/Scripts/Core/Events/JobStarted.cs
+++ b/Idle Skiller/Assets/_Project/Scripts/Core/Events/JobStarted.cs
@@ -1,0 +1,12 @@
+namespace IdleSkiller.Core.Events
+{
+    public readonly struct JobStarted
+    {
+        public readonly string JobId;
+
+        public JobStarted(string jobId)
+        {
+            JobId = jobId;
+        }
+    }
+}

--- a/Tests/EventBusTests.cs
+++ b/Tests/EventBusTests.cs
@@ -1,0 +1,59 @@
+using System;
+using IdleSkiller.Core.Events;
+using NUnit.Framework;
+
+namespace IdleSkiller.Tests
+{
+    public class EventBusTests
+    {
+        [Test]
+        public void PublishCallsSubscribers()
+        {
+            var bus = new EventBus();
+            JobStarted received = default;
+            bus.Subscribe<JobStarted>(e => received = e);
+
+            var evt = new JobStarted("test");
+            bus.Publish(evt);
+
+            Assert.That(received.JobId, Is.EqualTo("test"));
+        }
+
+        [Test]
+        public void UnsubscribeStopsReceiving()
+        {
+            var bus = new EventBus();
+            int callCount = 0;
+            Action<JobStarted> handler = _ => callCount++;
+
+            bus.Subscribe(handler);
+            bus.Unsubscribe(handler);
+            bus.Publish(new JobStarted("job"));
+
+            Assert.That(callCount, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void CanUnsubscribeDuringPublish()
+        {
+            var bus = new EventBus();
+            int count = 0;
+            Action<JobStarted> handler1 = null;
+            handler1 = e =>
+            {
+                count++;
+                bus.Unsubscribe(handler1);
+            };
+            Action<JobStarted> handler2 = e => count++;
+
+            bus.Subscribe(handler1);
+            bus.Subscribe(handler2);
+
+            bus.Publish(new JobStarted("job"));
+            Assert.That(count, Is.EqualTo(2));
+
+            bus.Publish(new JobStarted("job"));
+            Assert.That(count, Is.EqualTo(3));
+        }
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -17,5 +17,7 @@
     <Compile Include="..\Idle Skiller\Assets\_Project\Scripts\Systems\SaveData.cs" />
     <Compile Include="..\Idle Skiller\Assets\_Project\Scripts\Systems\InventoryService.cs" />
     <Compile Include="..\Idle Skiller\Assets\_Project\Scripts\Systems\CurrencyService.cs" />
+    <Compile Include="EventBusTests.cs" />
+    <Compile Include="..\Idle Skiller\Assets\_Project\Scripts\Core\Events\*.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- Introduce `IEventBus` and `EventBus` to publish and subscribe to struct-based events without per-frame allocations
- Define core events `JobStarted`, `JobCompleted`, and `CurrencyChanged`
- Add tests covering subscription, unsubscription, and safe unsubscription during publish

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aec4fcba8083269f09a7678ed60d6a