### PR TITLE
feat: implement progress job engine

### DIFF
--- a/Idle Skiller/Assets/_Project/Scripts/Core/Events.meta
+++ b/Idle Skiller/Assets/_Project/Scripts/Core/Events.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 82993ad5a7c14cf3a8d47277a0634ae9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Idle Skiller/Assets/_Project/Scripts/Core/Events/EventBus.cs
+++ b/Idle Skiller/Assets/_Project/Scripts/Core/Events/EventBus.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+
+namespace IdleSkiller.Core.Events
+{
+    /// <summary>
+    /// Basic in-memory implementation of <see cref="IEventBus"/>.
+    /// </summary>
+    public class EventBus : IEventBus
+    {
+        private readonly Dictionary<Type, List<Delegate>> _subscribers = new();
+
+        public void Subscribe<T>(Action<T> handler) where T : struct
+        {
+            var type = typeof(T);
+            if (!_subscribers.TryGetValue(type, out var list))
+            {
+                list = new List<Delegate>();
+                _subscribers[type] = list;
+            }
+
+            if (!list.Contains(handler))
+            {
+                list.Add(handler);
+            }
+        }
+
+        public void Unsubscribe<T>(Action<T> handler) where T : struct
+        {
+            var type = typeof(T);
+            if (_subscribers.TryGetValue(type, out var list))
+            {
+                list.Remove(handler);
+            }
+        }
+
+        public void Publish<T>(T evt) where T : struct
+        {
+            var type = typeof(T);
+            if (_subscribers.TryGetValue(type, out var list))
+            {
+                // iterate over copy to be safe against modifications during invoke
+                var copy = list.ToArray();
+                foreach (var del in copy)
+                {
+                    ((Action<T>)del)(evt);
+                }
+            }
+        }
+    }
+}

--- a/Idle Skiller/Assets/_Project/Scripts/Core/Events/EventBus.cs.meta
+++ b/Idle Skiller/Assets/_Project/Scripts/Core/Events/EventBus.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8b5091093a03442c9afc5e7c93bd73ce
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Idle Skiller/Assets/_Project/Scripts/Core/Events/IEventBus.cs
+++ b/Idle Skiller/Assets/_Project/Scripts/Core/Events/IEventBus.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace IdleSkiller.Core.Events
+{
+    /// <summary>
+    /// Simple publish/subscribe event bus.
+    /// </summary>
+    public interface IEventBus
+    {
+        /// <summary>
+        /// Subscribe to events of type <typeparamref name="T"/>.
+        /// </summary>
+        void Subscribe<T>(Action<T> handler) where T : struct;
+
+        /// <summary>
+        /// Unsubscribe from events of type <typeparamref name="T"/>.
+        /// </summary>
+        void Unsubscribe<T>(Action<T> handler) where T : struct;
+
+        /// <summary>
+        /// Publish an event to all subscribers.
+        /// </summary>
+        void Publish<T>(T evt) where T : struct;
+    }
+}

--- a/Idle Skiller/Assets/_Project/Scripts/Core/Events/IEventBus.cs.meta
+++ b/Idle Skiller/Assets/_Project/Scripts/Core/Events/IEventBus.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7eb2898a3300450b8634b0c488e7ee77
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Idle Skiller/Assets/_Project/Scripts/Core/Time.meta
+++ b/Idle Skiller/Assets/_Project/Scripts/Core/Time.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1c2175505ce88bd4a841c68b8179f254
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Idle Skiller/Assets/_Project/Scripts/Core/Time/ITimeService.cs.meta
+++ b/Idle Skiller/Assets/_Project/Scripts/Core/Time/ITimeService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b7843f14bc2b8654c8c770864270a534
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Idle Skiller/Assets/_Project/Scripts/Core/Time/OfflineGrant.cs.meta
+++ b/Idle Skiller/Assets/_Project/Scripts/Core/Time/OfflineGrant.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bd51a387dd4e3984fa6d04956d738bd4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Idle Skiller/Assets/_Project/Scripts/Core/Time/TimeService.cs.meta
+++ b/Idle Skiller/Assets/_Project/Scripts/Core/Time/TimeService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3f92dc9ce90fe8e48a1a2e1c44d4fd5e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Idle Skiller/Assets/_Project/Scripts/Systems/Progress.meta
+++ b/Idle Skiller/Assets/_Project/Scripts/Systems/Progress.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8189574f622d4ac0adc65298b80b7490
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Idle Skiller/Assets/_Project/Scripts/Systems/Progress/JobRunner.cs
+++ b/Idle Skiller/Assets/_Project/Scripts/Systems/Progress/JobRunner.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using IdleSkiller.Core.Events;
+
+namespace IdleSkiller.Systems.Progress
+{
+    /// <summary>
+    /// Updates active <see cref="ProgressJob"/> instances.
+    /// </summary>
+    public class JobRunner
+    {
+        private readonly IEventBus _eventBus;
+        private readonly List<ProgressJob> _jobs = new();
+        private readonly Random _random = new();
+
+        public JobRunner(IEventBus eventBus)
+        {
+            _eventBus = eventBus;
+        }
+
+        /// <summary>
+        /// Number of active jobs.
+        /// </summary>
+        public int ActiveJobCount => _jobs.Count;
+
+        /// <summary>
+        /// Begin tracking and updating the provided job.
+        /// </summary>
+        public void StartJob(ProgressJob job)
+        {
+            if (!_jobs.Contains(job))
+            {
+                job.Elapsed = 0f;
+                job.IsComplete = false;
+                job.IsCritical = false;
+                _jobs.Add(job);
+                _eventBus.Publish(new JobStarted(job));
+            }
+        }
+
+        /// <summary>
+        /// Advance all jobs by the specified delta time.
+        /// </summary>
+        public void Tick(float deltaTime)
+        {
+            for (int i = _jobs.Count - 1; i >= 0; i--)
+            {
+                var job = _jobs[i];
+                if (job.IsComplete)
+                {
+                    _jobs.RemoveAt(i);
+                    continue;
+                }
+
+                job.Elapsed += deltaTime * job.SpeedMultiplier;
+                if (job.Elapsed >= job.Duration)
+                {
+                    job.Elapsed = job.Duration;
+                    job.IsComplete = true;
+                    job.IsCritical = _random.NextDouble() < job.CritChance;
+                    _jobs.RemoveAt(i);
+                    _eventBus.Publish(new JobCompleted(job, job.IsCritical));
+                }
+            }
+        }
+    }
+}

--- a/Idle Skiller/Assets/_Project/Scripts/Systems/Progress/JobRunner.cs.meta
+++ b/Idle Skiller/Assets/_Project/Scripts/Systems/Progress/JobRunner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bae084665435479ba4502da35d372442
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Idle Skiller/Assets/_Project/Scripts/Systems/Progress/ProgressJob.cs
+++ b/Idle Skiller/Assets/_Project/Scripts/Systems/Progress/ProgressJob.cs
@@ -1,0 +1,74 @@
+using IdleSkiller.Core.Events;
+
+namespace IdleSkiller.Systems.Progress
+{
+    /// <summary>
+    /// Represents a job that progresses over time until completion.
+    /// </summary>
+    public class ProgressJob
+    {
+        public ProgressJob(float duration)
+        {
+            Duration = duration;
+            SpeedMultiplier = 1f;
+        }
+
+        /// <summary>
+        /// Total duration required to complete the job.
+        /// </summary>
+        public float Duration { get; }
+
+        /// <summary>
+        /// Speed multiplier applied when ticking progress.
+        /// </summary>
+        public float SpeedMultiplier { get; set; }
+
+        /// <summary>
+        /// Chance [0,1] that the job completes with a critical success.
+        /// </summary>
+        public float CritChance { get; set; }
+
+        /// <summary>
+        /// Elapsed time accrued on this job.
+        /// </summary>
+        public float Elapsed { get; internal set; }
+
+        /// <summary>
+        /// Whether the job has completed.
+        /// </summary>
+        public bool IsComplete { get; internal set; }
+
+        /// <summary>
+        /// Whether the job completed with a critical success.
+        /// </summary>
+        public bool IsCritical { get; internal set; }
+    }
+
+    /// <summary>
+    /// Event published when a job starts.
+    /// </summary>
+    public readonly struct JobStarted
+    {
+        public JobStarted(ProgressJob job)
+        {
+            Job = job;
+        }
+
+        public ProgressJob Job { get; }
+    }
+
+    /// <summary>
+    /// Event published when a job completes.
+    /// </summary>
+    public readonly struct JobCompleted
+    {
+        public JobCompleted(ProgressJob job, bool isCritical)
+        {
+            Job = job;
+            IsCritical = isCritical;
+        }
+
+        public ProgressJob Job { get; }
+        public bool IsCritical { get; }
+    }
+}

--- a/Idle Skiller/Assets/_Project/Scripts/Systems/Progress/ProgressJob.cs.meta
+++ b/Idle Skiller/Assets/_Project/Scripts/Systems/Progress/ProgressJob.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8b30ccebedf24d299613249b41387814
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Idle Skiller/Assets/_Project/Tests.meta
+++ b/Idle Skiller/Assets/_Project/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 11102f0b5cca91645946a0ebec2f4bf0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Idle Skiller/Assets/_Project/Tests/Tests.csproj.meta
+++ b/Idle Skiller/Assets/_Project/Tests/Tests.csproj.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c37ebcfd68b7cf742a8c588ec4167de1
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Idle Skiller/Assets/_Project/Tests/TimeServiceTests.cs.meta
+++ b/Idle Skiller/Assets/_Project/Tests/TimeServiceTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 45e8e1534cda6bb4fa8d1814df01e863
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/ProgressJobTests.cs
+++ b/Tests/ProgressJobTests.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using IdleSkiller.Core.Events;
+using IdleSkiller.Systems.Progress;
+using NUnit.Framework;
+
+namespace Tests
+{
+    public class ProgressJobTests
+    {
+        private EventBus _bus;
+        private JobRunner _runner;
+        private List<JobStarted> _started;
+        private List<JobCompleted> _completed;
+
+        [SetUp]
+        public void Setup()
+        {
+            _bus = new EventBus();
+            _runner = new JobRunner(_bus);
+            _started = new List<JobStarted>();
+            _completed = new List<JobCompleted>();
+            _bus.Subscribe<JobStarted>(e => _started.Add(e));
+            _bus.Subscribe<JobCompleted>(e => _completed.Add(e));
+        }
+
+        [Test]
+        public void Tick_CompletesJob_And_FiresEvents()
+        {
+            var job = new ProgressJob(5f) { SpeedMultiplier = 1f };
+            _runner.StartJob(job);
+            for (int i = 0; i < 5; i++)
+            {
+                _runner.Tick(1f);
+            }
+
+            Assert.AreEqual(1, _started.Count);
+            Assert.AreEqual(1, _completed.Count);
+            Assert.True(job.IsComplete);
+            Assert.AreEqual(0, _runner.ActiveJobCount);
+        }
+
+        [Test]
+        public void Crit_Succeeds_When_ChanceIsCertain()
+        {
+            var job = new ProgressJob(1f) { CritChance = 1f };
+            _runner.StartJob(job);
+            _runner.Tick(1f);
+
+            Assert.AreEqual(1, _completed.Count);
+            Assert.True(_completed[0].IsCritical);
+            Assert.True(job.IsCritical);
+        }
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -14,8 +14,13 @@
 
   <ItemGroup>
     <Compile Include="InventoryServiceTests.cs" />
+    <Compile Include="ProgressJobTests.cs" />
     <Compile Include="..\Idle Skiller\Assets\_Project\Scripts\Systems\SaveData.cs" />
     <Compile Include="..\Idle Skiller\Assets\_Project\Scripts\Systems\InventoryService.cs" />
     <Compile Include="..\Idle Skiller\Assets\_Project\Scripts\Systems\CurrencyService.cs" />
+    <Compile Include="..\Idle Skiller\Assets\_Project\Scripts\Core\Events\IEventBus.cs" />
+    <Compile Include="..\Idle Skiller\Assets\_Project\Scripts\Core\Events\EventBus.cs" />
+    <Compile Include="..\Idle Skiller\Assets\_Project\Scripts\Systems\Progress\ProgressJob.cs" />
+    <Compile Include="..\Idle Skiller\Assets\_Project\Scripts\Systems\Progress\JobRunner.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- add lightweight event bus for publish/subscribe
- create progress jobs and job runner that fire start/complete events
- cover job ticking, completion and crits with tests

## Testing
- ⚠️ `dotnet test` *(dotnet not installed: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68aec51d9230832682b23d1f49812761