### PR TITLE
Implement gathering system with node assets and tests

### DIFF
--- a/Idle Skiller/Assets/_Project/Data/Gathering.meta
+++ b/Idle Skiller/Assets/_Project/Data/Gathering.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d226b87b96c74db9b43d7c6ee625c3e7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Idle Skiller/Assets/_Project/Data/Gathering/HerbsNode.asset
+++ b/Idle Skiller/Assets/_Project/Data/Gathering/HerbsNode.asset
@@ -1,0 +1,23 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dd3dfb5a8389453a99dfb36fdb3d31f2, type: 3}
+  m_Name: HerbsNode
+  m_EditorClassIdentifier:
+  OutputItemId: herbs
+  Durations:
+  - 4
+  - 8
+  - 12
+  Yields:
+  - 1
+  - 2
+  - 3

--- a/Idle Skiller/Assets/_Project/Data/Gathering/HerbsNode.asset.meta
+++ b/Idle Skiller/Assets/_Project/Data/Gathering/HerbsNode.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c82bd0328f45465a9482c3cf1db9fee6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Idle Skiller/Assets/_Project/Data/Gathering/OreNode.asset
+++ b/Idle Skiller/Assets/_Project/Data/Gathering/OreNode.asset
@@ -1,0 +1,23 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dd3dfb5a8389453a99dfb36fdb3d31f2, type: 3}
+  m_Name: OreNode
+  m_EditorClassIdentifier:
+  OutputItemId: ore
+  Durations:
+  - 10
+  - 20
+  - 30
+  Yields:
+  - 1
+  - 2
+  - 3

--- a/Idle Skiller/Assets/_Project/Data/Gathering/OreNode.asset.meta
+++ b/Idle Skiller/Assets/_Project/Data/Gathering/OreNode.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 82df2baf9e8848ec9f1b01a811d873d7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Idle Skiller/Assets/_Project/Data/Gathering/StoneNode.asset
+++ b/Idle Skiller/Assets/_Project/Data/Gathering/StoneNode.asset
@@ -1,0 +1,23 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dd3dfb5a8389453a99dfb36fdb3d31f2, type: 3}
+  m_Name: StoneNode
+  m_EditorClassIdentifier:
+  OutputItemId: stone
+  Durations:
+  - 6
+  - 12
+  - 18
+  Yields:
+  - 1
+  - 2
+  - 3

--- a/Idle Skiller/Assets/_Project/Data/Gathering/StoneNode.asset.meta
+++ b/Idle Skiller/Assets/_Project/Data/Gathering/StoneNode.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b83b3b1452ec4c1d9fbd4a25a708ce5d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Idle Skiller/Assets/_Project/Data/Gathering/WoodNode.asset
+++ b/Idle Skiller/Assets/_Project/Data/Gathering/WoodNode.asset
@@ -1,0 +1,23 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dd3dfb5a8389453a99dfb36fdb3d31f2, type: 3}
+  m_Name: WoodNode
+  m_EditorClassIdentifier:
+  OutputItemId: wood
+  Durations:
+  - 5
+  - 10
+  - 15
+  Yields:
+  - 1
+  - 2
+  - 3

--- a/Idle Skiller/Assets/_Project/Data/Gathering/WoodNode.asset.meta
+++ b/Idle Skiller/Assets/_Project/Data/Gathering/WoodNode.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1d5ec68fdc1f4e7e8381d3d5918bda6c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Idle Skiller/Assets/_Project/Scripts/Systems/Gathering.meta
+++ b/Idle Skiller/Assets/_Project/Scripts/Systems/Gathering.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9b3726b474f0401fb8b9e52b4d6846fb
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Idle Skiller/Assets/_Project/Scripts/Systems/Gathering/GatheringNodeDef.cs
+++ b/Idle Skiller/Assets/_Project/Scripts/Systems/Gathering/GatheringNodeDef.cs
@@ -1,0 +1,15 @@
+using UnityEngine;
+
+namespace IdleSkiller.Systems.Gathering
+{
+    [CreateAssetMenu(menuName = "IdleSkiller/Gathering/Node")]
+    public class GatheringNodeDef : ScriptableObject, IGatheringNode
+    {
+        public string OutputItemId;
+        public float[] Durations = new float[3];
+        public int[] Yields = new int[3];
+
+        public float GetDuration(int tier) => tier > 0 && tier <= Durations.Length ? Durations[tier - 1] : 0f;
+        public int GetYield(int tier) => tier > 0 && tier <= Yields.Length ? Yields[tier - 1] : 0;
+    }
+}

--- a/Idle Skiller/Assets/_Project/Scripts/Systems/Gathering/GatheringNodeDef.cs.meta
+++ b/Idle Skiller/Assets/_Project/Scripts/Systems/Gathering/GatheringNodeDef.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dd3dfb5a8389453a99dfb36fdb3d31f2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Idle Skiller/Assets/_Project/Scripts/Systems/Gathering/GatheringSystem.cs
+++ b/Idle Skiller/Assets/_Project/Scripts/Systems/Gathering/GatheringSystem.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace IdleSkiller.Systems.Gathering
+{
+    public class GatheringSystem
+    {
+        private readonly InventoryService _inventory;
+        private readonly float _durationMultiplier;
+        private readonly float _yieldMultiplier;
+
+        public event Action<string>? Telemetry;
+
+        public GatheringSystem(InventoryService inventory, float durationMultiplier = 1f, float yieldMultiplier = 1f)
+        {
+            _inventory = inventory;
+            _durationMultiplier = durationMultiplier;
+            _yieldMultiplier = yieldMultiplier;
+        }
+
+        public float GetDuration(IGatheringNode node, int tier)
+        {
+            return node.GetDuration(tier) * _durationMultiplier;
+        }
+
+        public int Gather(IGatheringNode node, int tier)
+        {
+            Telemetry?.Invoke("run");
+            var amount = (int)MathF.Round(node.GetYield(tier) * _yieldMultiplier);
+            _inventory.AddItem(node.OutputItemId, amount);
+            Telemetry?.Invoke("complete");
+            return amount;
+        }
+    }
+}

--- a/Idle Skiller/Assets/_Project/Scripts/Systems/Gathering/GatheringSystem.cs.meta
+++ b/Idle Skiller/Assets/_Project/Scripts/Systems/Gathering/GatheringSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a3a6f3b45a3d40f3ae0801282c58e445
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Idle Skiller/Assets/_Project/Scripts/Systems/Gathering/IGatheringNode.cs
+++ b/Idle Skiller/Assets/_Project/Scripts/Systems/Gathering/IGatheringNode.cs
@@ -1,0 +1,9 @@
+namespace IdleSkiller.Systems.Gathering
+{
+    public interface IGatheringNode
+    {
+        string OutputItemId { get; }
+        float GetDuration(int tier);
+        int GetYield(int tier);
+    }
+}

--- a/Idle Skiller/Assets/_Project/Scripts/Systems/Gathering/IGatheringNode.cs.meta
+++ b/Idle Skiller/Assets/_Project/Scripts/Systems/Gathering/IGatheringNode.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5b1c3be2446a4fb8812681bdc459daaa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/GatheringSystemTests.cs
+++ b/Tests/GatheringSystemTests.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using IdleSkiller.Systems;
+using IdleSkiller.Systems.Gathering;
+using NUnit.Framework;
+
+namespace Tests
+{
+    public class GatheringSystemTests
+    {
+        private SaveData _saveData = null!;
+        private InventoryService _inventory = null!;
+        private GatheringSystem _system = null!;
+
+        private class TestNode : IGatheringNode
+        {
+            private readonly float[] _durations;
+            private readonly int[] _yields;
+            public string OutputItemId { get; }
+
+            public TestNode(string itemId, float[] durations, int[] yields)
+            {
+                OutputItemId = itemId;
+                _durations = durations;
+                _yields = yields;
+            }
+
+            public float GetDuration(int tier) => _durations[tier - 1];
+            public int GetYield(int tier) => _yields[tier - 1];
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            _saveData = new SaveData { InventoryCapacity = 100 };
+            _inventory = new InventoryService(_saveData);
+            _system = new GatheringSystem(_inventory, durationMultiplier: 2f, yieldMultiplier: 1.5f);
+        }
+
+        [Test]
+        public void GetDuration_UsesMultiplier()
+        {
+            var node = new TestNode("wood", new[] { 5f, 10f, 15f }, new[] { 1, 2, 3 });
+            var duration = _system.GetDuration(node, 2);
+            Assert.AreEqual(20f, duration);
+        }
+
+        [Test]
+        public void Gather_AddsItemsWithYieldMultiplier()
+        {
+            var node = new TestNode("stone", new[] { 6f, 12f, 18f }, new[] { 2, 4, 6 });
+            var added = _system.Gather(node, 1);
+            Assert.AreEqual(3, added);
+            Assert.True(_inventory.HasItems("stone", 3));
+        }
+
+        [Test]
+        public void Gather_EmitsTelemetry()
+        {
+            var node = new TestNode("ore", new[] { 10f, 20f, 30f }, new[] { 1, 2, 3 });
+            var events = new List<string>();
+            _system.Telemetry += events.Add;
+            _system.Gather(node, 1);
+            CollectionAssert.AreEqual(new[] { "run", "complete" }, events);
+        }
+    }
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -14,8 +14,11 @@
 
   <ItemGroup>
     <Compile Include="InventoryServiceTests.cs" />
+    <Compile Include="GatheringSystemTests.cs" />
     <Compile Include="..\Idle Skiller\Assets\_Project\Scripts\Systems\SaveData.cs" />
     <Compile Include="..\Idle Skiller\Assets\_Project\Scripts\Systems\InventoryService.cs" />
     <Compile Include="..\Idle Skiller\Assets\_Project\Scripts\Systems\CurrencyService.cs" />
+    <Compile Include="..\Idle Skiller\Assets\_Project\Scripts\Systems\Gathering\IGatheringNode.cs" />
+    <Compile Include="..\Idle Skiller\Assets\_Project\Scripts\Systems\Gathering\GatheringSystem.cs" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- add `GatheringSystem` that applies duration and yield multipliers, integrates `InventoryService`, and emits simple telemetry
- define `GatheringNodeDef` ScriptableObject and `IGatheringNode` interface
- create sample node assets for Wood, Stone, Ore, and Herbs
- add unit tests for gathering duration, yield, and telemetry

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aec531ccd8832683da6db4eb280560