### PR TITLE
Add worker service and model

### DIFF
--- a/Idle Skiller/Assets/_Project/Scripts/Systems/SaveData.cs
+++ b/Idle Skiller/Assets/_Project/Scripts/Systems/SaveData.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using IdleSkiller.Systems.Workers;
 
 namespace IdleSkiller.Systems
 {
@@ -11,5 +12,7 @@ namespace IdleSkiller.Systems
         public int InventoryCapacity { get; set; } = 0;
 
         public Dictionary<string, int> Inventory { get; set; } = new Dictionary<string, int>();
+
+        public List<Worker> Workers { get; set; } = new List<Worker>();
     }
 }

--- a/Idle Skiller/Assets/_Project/Scripts/Systems/Workers.meta
+++ b/Idle Skiller/Assets/_Project/Scripts/Systems/Workers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 03ec2a5b76204b3dac2af4fca98b0670
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Idle Skiller/Assets/_Project/Scripts/Systems/Workers/Worker.cs
+++ b/Idle Skiller/Assets/_Project/Scripts/Systems/Workers/Worker.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+
+namespace IdleSkiller.Systems.Workers
+{
+    public enum WorkerState
+    {
+        Idle,
+        Working,
+        Cooldown
+    }
+
+    [Serializable]
+    public class Worker
+    {
+        public string Name = string.Empty;
+        public Dictionary<string, int> SkillLevels = new Dictionary<string, int>();
+        public Dictionary<string, string> EquipmentSlots = new Dictionary<string, string>();
+        public WorkerState State = WorkerState.Idle;
+
+        private const float LevelPercent = 0.01f;
+
+        private int GetLevel(string skill) => SkillLevels.TryGetValue(skill, out var lvl) ? lvl : 0;
+
+        public float GetSpeedPercent(string skill) => 1f + GetLevel(skill) * LevelPercent;
+        public float GetYieldPercent(string skill) => 1f + GetLevel(skill) * LevelPercent;
+        public float GetCritPercent(string skill) => GetLevel(skill) * LevelPercent;
+        public float GetXpPercent(string skill) => 1f + GetLevel(skill) * LevelPercent;
+    }
+}

--- a/Idle Skiller/Assets/_Project/Scripts/Systems/Workers/Worker.cs.meta
+++ b/Idle Skiller/Assets/_Project/Scripts/Systems/Workers/Worker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 31189870737640a2ab3eb26fb3f36f5a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Idle Skiller/Assets/_Project/Scripts/Systems/Workers/WorkerFactory.cs
+++ b/Idle Skiller/Assets/_Project/Scripts/Systems/Workers/WorkerFactory.cs
@@ -1,0 +1,14 @@
+namespace IdleSkiller.Systems.Workers
+{
+    public static class WorkerFactory
+    {
+        public static Worker CreateInitial()
+        {
+            return new Worker
+            {
+                Name = "Worker",
+                State = WorkerState.Idle
+            };
+        }
+    }
+}

--- a/Idle Skiller/Assets/_Project/Scripts/Systems/Workers/WorkerFactory.cs.meta
+++ b/Idle Skiller/Assets/_Project/Scripts/Systems/Workers/WorkerFactory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2de93af7cb2e4e3fa33a21e747d28e66
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Idle Skiller/Assets/_Project/Scripts/Systems/Workers/WorkerService.cs
+++ b/Idle Skiller/Assets/_Project/Scripts/Systems/Workers/WorkerService.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using IdleSkiller.Systems;
+
+namespace IdleSkiller.Systems.Workers
+{
+    public class WorkerService
+    {
+        private readonly SaveData _saveData;
+
+        public WorkerService(SaveData saveData)
+        {
+            _saveData = saveData;
+            if (_saveData.Workers.Count == 0)
+            {
+                _saveData.Workers.Add(WorkerFactory.CreateInitial());
+            }
+        }
+
+        public IReadOnlyList<Worker> Workers => _saveData.Workers;
+
+        public Worker AddWorker(Worker worker)
+        {
+            _saveData.Workers.Add(worker);
+            return worker;
+        }
+    }
+}

--- a/Idle Skiller/Assets/_Project/Scripts/Systems/Workers/WorkerService.cs.meta
+++ b/Idle Skiller/Assets/_Project/Scripts/Systems/Workers/WorkerService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7e0e906a0e444acebcc4505f10af284b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Idle Skiller/Assets/_Project/Tests/Tests.csproj
+++ b/Idle Skiller/Assets/_Project/Tests/Tests.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="../Scripts/Core/Time/*.cs" />
+    <Compile Include="../Scripts/Systems/**/*.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NUnit" Version="4.1.0" />

--- a/Idle Skiller/Assets/_Project/Tests/WorkerServiceTests.cs
+++ b/Idle Skiller/Assets/_Project/Tests/WorkerServiceTests.cs
@@ -1,0 +1,33 @@
+using IdleSkiller.Systems;
+using IdleSkiller.Systems.Workers;
+using NUnit.Framework;
+
+namespace IdleSkiller.Tests
+{
+    public class WorkerServiceTests
+    {
+        [Test]
+        public void Constructor_AddsInitialWorker()
+        {
+            var save = new SaveData();
+            var service = new WorkerService(save);
+
+            Assert.That(service.Workers.Count, Is.EqualTo(1));
+            var worker = service.Workers[0];
+            Assert.That(worker.Name, Is.EqualTo("Worker"));
+            Assert.That(worker.State, Is.EqualTo(WorkerState.Idle));
+        }
+
+        [Test]
+        public void DerivedStats_FromSkillLevel()
+        {
+            var worker = WorkerFactory.CreateInitial();
+            worker.SkillLevels["mining"] = 10;
+
+            Assert.That(worker.GetSpeedPercent("mining"), Is.EqualTo(1.1f));
+            Assert.That(worker.GetYieldPercent("mining"), Is.EqualTo(1.1f));
+            Assert.That(worker.GetCritPercent("mining"), Is.EqualTo(0.1f));
+            Assert.That(worker.GetXpPercent("mining"), Is.EqualTo(1.1f));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add Worker model with skill levels, equipment slots, and derived stat helpers
- Introduce WorkerService and factory to manage and spawn initial workers
- Persist worker list in save data and cover behavior with new unit tests

## Testing
- `dotnet test 'Idle Skiller/Assets/_Project/Tests/Tests.csproj'` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aec559c9e08326bbb73979dbcc22f5